### PR TITLE
sepolicy: Fix neverallow on user builds

### DIFF
--- a/common/private/recovery.te
+++ b/common/private/recovery.te
@@ -12,8 +12,10 @@ r_dir_file(recovery, adb_keys_file)
 set_prop(recovery, shell_prop)
 
 # Manage fstab and /adb_keys
+userdebug_or_eng(`
 allow recovery rootfs:file create_file_perms;
 allow recovery rootfs:file link;
+')
 allow recovery rootfs:dir { write create rmdir add_name remove_name };
 
 # Sideload cache


### PR DESCRIPTION
This is in the LineageOS sepolicy and we cannot build lineage_*-user builds without this commit due to a conflict of interest in recovery.

Change-Id: I80fda6b3e368cc0e218667a12d0378695434f361