### PR TITLE
updater_app: Address cache_file denials

### DIFF
--- a/common/private/updater_app.te
+++ b/common/private/updater_app.te
@@ -15,6 +15,7 @@ allow updater_app app_data_file:dir create_dir_perms;
 allow updater_app app_data_file:{ file lnk_file } create_file_perms;
 
 allow updater_app cache_file:dir rw_dir_perms;
+allow updater_app cache_file:file create_file_perms;
 
 allow updater_app cache_recovery_file:dir rw_dir_perms;
 allow updater_app cache_recovery_file:file create_file_perms;


### PR DESCRIPTION
crdroid.updater: type=1400 audit(0.0:3984): avc: denied { create } for name="uncrypt_file" scontext=u:r:updater_app:s0:c512,c768 tcontext=u:object_r:cache_file:s0:c512,c768 tclass=file permissive=0 app=com.crdroid.updater

Signed-off-by: Jabiyeff <cebiyevanar@gmail.com>