### PR TITLE
sepolicy: include flipendo/turbo_adapter policy

### DIFF
--- a/common/sepolicy.mk
+++ b/common/sepolicy.mk
@@ -10,7 +10,7 @@ endif
 endif
 
 SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += \
-    device/lineage/sepolicy/common/public
+    device/lineage/sepolicy/common/public \
 
 SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/lineage/sepolicy/common/private
@@ -18,11 +18,13 @@ SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
 ifeq ($(TARGET_USES_PREBUILT_VENDOR_SEPOLICY), true)
 SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/lineage/sepolicy/common/dynamic \
-    device/lineage/sepolicy/common/system
+    device/lineage/sepolicy/common/system \
+    hardware/google/pixel-sepolicy/turbo_adapter
 else
 BOARD_VENDOR_SEPOLICY_DIRS += \
     device/lineage/sepolicy/common/dynamic \
-    device/lineage/sepolicy/common/vendor
+    device/lineage/sepolicy/common/vendor \
+    hardware/google/pixel-sepolicy/turbo_adapter
 endif
 
 # Selectively include legacy rules defined by the products


### PR DESCRIPTION
Signed-off-by: Matt Filetto <matt.filetto@gmail.com>

Pixels need this to build successfully 