### PR TITLE
common: trust: Add sepolicy for dwc3 usb_data_enabled

### DIFF
--- a/common/dynamic/file.te
+++ b/common/dynamic/file.te
@@ -1,2 +1,3 @@
 type proc_deny_new_usb, fs_type, proc_type;
 type sysfs_livedisplay_tuneable, fs_type, sysfs_type;
+type sysfs_usb_data_enabled, fs_type, sysfs_type;

--- a/common/dynamic/hal_lineage_trust.te
+++ b/common/dynamic/hal_lineage_trust.te
@@ -7,3 +7,4 @@ allow hal_lineage_trust_client hal_lineage_trust_hwservice:hwservice_manager fin
 allow hal_lineage_trust_server self:capability sys_admin;
 
 allow hal_lineage_trust_server proc_deny_new_usb:file rw_file_perms;
+allow hal_lineage_trust_server sysfs_usb_data_enabled:file rw_file_perms;


### PR DESCRIPTION
Change-Id: I9af25e1ed0af9697a1db9c5ac9e207141e1062e3

Keeping up with upstream LOS (so I can merge latest changes in my device tree as well without having to keep extra reverts).