### PR TITLE
lineage: Make Health service discoverable by Settings app

### DIFF
--- a/common/private/system_app.te
+++ b/common/private/system_app.te
@@ -5,6 +5,7 @@ get_prop(system_app, vendor_security_patch_level_prop)
 hal_client_domain(system_app, hal_lineage_fastcharge)
 hal_client_domain(system_app, hal_lineage_livedisplay)
 hal_client_domain(system_app, hal_lineage_touch)
+hal_client_domain(system_app, hal_lineage_health)
 
 # Allow SetupWizard to set recovery update prop
 set_prop(system_app, recovery_update_prop)


### PR DESCRIPTION
E JavaBinder: !!! FAILED BINDER TRANSACTION !!!  (parcel size = 0)
W com.android.settings: type=1400 audit(0.0:26): avc: denied { call } for comm=4173796E635461736B20233134 scontext=u:r:system_app:s0 tcontext=u:r:hal_lineage_health_default:s0 tclass=binder permissive=0
binder  : 4081:10372 transaction failed 29201/-1, size 0-0 line 3012
