### PR TITLE
sepolicy: Label more dirty writeback parameters

### DIFF
--- a/common/private/genfs_contexts
+++ b/common/private/genfs_contexts
@@ -1,2 +1,4 @@
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon sysfs /devices/virtual/timed_output/vibrator u:object_r:sysfs_vibrator:s0
 genfscon sysfs /module/mmcblk/parameters/perdev_minors u:object_r:sysfs_perdev_minors:s0


### PR DESCRIPTION
Needed after system/core change ID I22f9ec9010dd028710a1a5c2e3d26d8444a4c914:

"init.rc: tune dirty data writebacks"
___

Since we're making a global change in system/core/ to adjust memory handling, let's make a global change in sepolicy to allow it to happen, yeah?